### PR TITLE
Use system javac to compile the executable program.

### DIFF
--- a/annotation-file-utilities/tests/Makefile
+++ b/annotation-file-utilities/tests/Makefile
@@ -15,6 +15,7 @@
 #   JAVA=${JAVA_HOME}/bin/java
 #   JAVAC=${JAVA_HOME}/bin/javac
 JAVA?=java -ea
+JAVAC?=javac
 XJAVAC?=javac
 
 export SHELL=/bin/bash -o pipefail
@@ -53,7 +54,7 @@ results: bin/VerifyDiffs.class
 
 # Remakes the little java program that checks and compares diffs
 bin/VerifyDiffs.class : VerifyDiffs.java
-	@$(XJAVAC) -g -cp ../bincompile -d bin VerifyDiffs.java
+	@$(JAVAC) -g -cp ../bincompile -d bin VerifyDiffs.java
 
 # Compiles all the test cases (be verbose about this).
 compile :


### PR DESCRIPTION
Use system javac to compile the executable program to allow java 7 execution.

There are two Makefiles (annotation-tools/annotation-file-utilities/test/Makefile and annotation-file-utilities/tests/source-extension/Makefile) try to compile the same class (annotation-file-utilities/tests/VerifyDiffs.java) while using different compilers.(system javac and jsr308 javac) This will cause version 52 error when system jdk is jdk 7.

Thus, unified this difference to both use system javac to compile the executable program.