### PR TITLE
add annotations import

### DIFF
--- a/annotation-file-utilities/src/annotator/Main.java
+++ b/annotation-file-utilities/src/annotator/Main.java
@@ -553,6 +553,8 @@ public class Main {
         new HashMap<String, Multimap<Insertion, Annotation>>();
     Map<Insertion, String> insertionOrigins = new HashMap<Insertion, String>();
     Map<String, AScene> scenes = new HashMap<String, AScene>();
+    // maintain imports info for annotations field
+    Map<String, Set<String>> annotationImports = new HashMap<>();
 
     IndexFileParser.setAbbreviate(abbreviate);
     for (String arg : file_args) {
@@ -625,6 +627,7 @@ public class Main {
           }
           System.exit(1);
         }
+        annotationImports.putAll(spec.annotationImports());
       } else {
         throw new Error("Unrecognized file extension: " + arg);
       }
@@ -678,6 +681,13 @@ public class Main {
 
       // Imports required to resolve annotations (when abbreviate==true).
       LinkedHashSet<String> imports = new LinkedHashSet<String>();
+      // add annotation imports first
+      if (!annotationImports.isEmpty()) {
+          for (Set<String> importSet : annotationImports.values()) {
+              imports.addAll(importSet);
+          }
+      }
+
       int num_insertions = 0;
       String pkg = "";
 

--- a/scene-lib/src/annotations/io/IndexFileParser.java
+++ b/scene-lib/src/annotations/io/IndexFileParser.java
@@ -569,7 +569,7 @@ public final class IndexFileParser {
                 }
                 if (set2 == null) {
                   set2 = new TreeSet<String>();
-                  scene.imports.put(name, set2);
+                  scene.imports.put(baseName, set2);
                 }
                 set1.add(name);
                 set2.add(name);


### PR DESCRIPTION
Propagate `annotationImports` information stored in `Ascene spec` to `imports` in `Main`.

This could enable  AFU also import the class of enum field of an annotation if that enum field declared with full qualified name in jaif file like this:

```
package ontology.qual:
  annotation @Ontology:
    enum ontology.qual.OntologyValue[] values
```

The imports of above jaif file in source code would be:

```java
import ontology.qual.Ontology;
import ontology.qual.OntologyValue; // note, this one is extracted by the full qualified declaration of 
                                                              // enum ontology.qual.OntologyValue[] values, not inferred by 
                                                              // package declaration.
```