### PR TITLE
Only include the required Guava packages. This saves about another 10%

### DIFF
--- a/annotation-file-utilities/build.xml
+++ b/annotation-file-utilities/build.xml
@@ -205,7 +205,9 @@
     </unjar>
     <unjar src="lib/guava-15.0.jar" dest="${temp-jarfile}">
       <patternset>
-        <include name="**/*.class"/>
+        <include name="com/google/common/base/**/*.class"/>
+        <include name="com/google/common/collect/**/*.class"/>
+        <include name="com/google/common/escape/**/*.class"/>
         <exclude name="META-INF/" />
       </patternset>
     </unjar>


### PR DESCRIPTION
on the Checker Framework jar file.