### PR TITLE
Remove bootclasspath hacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: false
 
 jdk:
   - oraclejdk8
-#  - oraclejdk7
-  - openjdk7
 
 jobs:
   include:

--- a/annotation-file-utilities/build.xml
+++ b/annotation-file-utilities/build.xml
@@ -502,18 +502,10 @@
     </fileset>
     <pathconvert property="cmdTxts" refid="javacSrc" pathsep=" " />
 
-      <!--
-        Hack for Mac OS: put jsr308's javac.jar on the bootclasspath so
-        that those javac classes are found before the stock javac classes
-        (other platforms do not make such bootclasspath inclusions).
-        Hack for Windows:  use "java com.sun.tools.javac.Main" rather than
-        "javac".
-      -->
       <java fork="true"
             failonerror="true"
             classpathref="libpath"
             classname="com.sun.tools.javac.Main">
-          <jvmarg line="-Xbootclasspath/p:${annotations-compiler-absolute}/dist/lib/javac.jar"/>
           <arg value="-Xlint:-options"/>
           <arg value="-Werror"/>
           <arg value="-g"/>

--- a/annotation-file-utilities/scripts/extract-annotations
+++ b/annotation-file-utilities/scripts/extract-annotations
@@ -14,7 +14,6 @@ fi
 
 AFU=${AFU:-$(dirname $0)/..}
 ANNOTATION_FILE_UTILS=${AFU}/bin:${AFU}/../scene-lib/bin:${AFU}/../asmx/bin:${AFU}/annotation-file-utilities.jar
-# Contains new version of java.lang.annotation.ElementType.
 LANGTOOLS=${LANGTOOLS:-${AFU}/../../jsr308-langtools}
 JAVAC_JAR=${JAVAC_JAR:-${LANGTOOLS}/dist/lib/javac.jar}
 
@@ -25,9 +24,9 @@ if [ "$DEBUG" = "1" ]; then
   echo "LANGTOOLS=${LANGTOOLS}"
   echo "JAVAC_JAR=${JAVAC_JAR}"
   # Keep this in sync with the actual command below.
-  echo java -Xbootclasspath/p:${JAVAC_JAR} -ea -cp ${AFU}/lib/plume-core.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileReader "$@"
+  echo java -ea -cp ${JAVAC_JAR}:${AFU}/lib/plume-core.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileReader "$@"
   echo "--- end of extract-annotations debugging output"
 fi
 
 # Needs CLASSPATH to find user files
-java -Xbootclasspath/p:${JAVAC_JAR} -ea -cp ${AFU}/lib/plume-core.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileReader "$@"
+java -ea -cp ${JAVAC_JAR}:${AFU}/lib/plume-core.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileReader "$@"

--- a/annotation-file-utilities/scripts/extract-annotations.bat
+++ b/annotation-file-utilities/scripts/extract-annotations.bat
@@ -6,10 +6,9 @@
 set ANNOTATION_FILE_UTILS=%~d0
 set ANNOTATION_FILE_UTILS=%ANNOTATION_FILE_UTILS%%~p0
 set ANNOTATION_FILE_UTILS=%ANNOTATION_FILE_UTILS%\..\annotation-file-utilities.jar
-:: Contains new version of java.lang.annotation.ElementType.
 set JAVAC_JAR=%~d0
 set JAVAC_JAR=%ANNOTATION_FILE_UTILS%%~p0
 set JAVAC_JAR=%JAVAC_JAR%..\..\..\jsr308-langtools\dist\lib\javac.jar
 
-java -ea "-Xbootclasspath/p:%ANNOTATION_FILE_UTILS%;%JAVAC_JAR%" -cp "%ANNOTATION_FILE_UTILS%;%CLASSPATH%" annotations.io.classfile.ClassFileReader %*
+java -ea -cp "%JAVAC_JAR%;%ANNOTATION_FILE_UTILS%;%CLASSPATH%" annotations.io.classfile.ClassFileReader %*
 

--- a/annotation-file-utilities/scripts/insert-annotations
+++ b/annotation-file-utilities/scripts/insert-annotations
@@ -14,7 +14,6 @@ fi
 
 AFU=${AFU:-$(dirname $0)/..}
 ANNOTATION_FILE_UTILS=${AFU}/bin:${AFU}/../scene-lib/bin:${AFU}/../asmx/bin:${AFU}/annotation-file-utilities.jar
-# Contains new version of java.lang.annotation.ElementType.
 LANGTOOLS=${LANGTOOLS:-${AFU}/../../jsr308-langtools}
 JAVAC_JAR=${JAVAC_JAR:-${LANGTOOLS}/dist/lib/javac.jar}
 
@@ -25,12 +24,9 @@ if [ "$DEBUG" = "1" ]; then
   echo "LANGTOOLS=${LANGTOOLS}"
   echo "JAVAC_JAR=${JAVAC_JAR}"
   # Keep this in sync with the actual command below.
-  echo "java -ea -Xbootclasspath/p:${ANNOTATION_FILE_UTILS}:${JAVAC_JAR}:${CLASSPATH} -cp ${AFU}/lib/plume-lib.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileWriter $@"
+  echo "java -ea -cp ${JAVAC_JAR}:${AFU}/lib/plume-lib.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileWriter $@"
   echo "--- end of insert-annotations debugging output"
 fi
 
 # Needs CLASSPATH to find user files
-# TODO: It is not nice that the CLASSPATH has to be on the bootclasspath!
-# Without it, e.g. building the Checker Framework annotated JDK does
-# not work.
-java -ea -Xbootclasspath/p:${AFU}/lib/plume-lib.jar:${ANNOTATION_FILE_UTILS}:${JAVAC_JAR}:${CLASSPATH} -cp ${AFU}/lib/plume-lib.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileWriter "$@"
+java -ea -cp ${JAVAC_JAR}:${AFU}/lib/plume-lib.jar:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotations.io.classfile.ClassFileWriter "$@"

--- a/annotation-file-utilities/scripts/insert-annotations-to-source
+++ b/annotation-file-utilities/scripts/insert-annotations-to-source
@@ -15,7 +15,6 @@ fi
 AFU=${AFU:-$(dirname $0)/..}
 AFU=`cd \`dirname $0\`/.. && pwd`
 ANNOTATION_FILE_UTILS=${ANNOTATION_FILE_UTILS:-${AFU}/bin:${AFU}/../scene-lib/bin:${AFU}/../asmx/bin:${AFU}/annotation-file-utilities.jar}
-# Contains new version of java.lang.annotation.ElementType.
 LANGTOOLS=${LANGTOOLS:-${AFU}/../../jsr308-langtools}
 JAVAC_JAR=${JAVAC_JAR:-${LANGTOOLS}/dist/lib/javac.jar}
 
@@ -26,10 +25,9 @@ if [ "$DEBUG" = "1" ]; then
   echo "LANGTOOLS=${LANGTOOLS}"
   echo "JAVAC_JAR=${JAVAC_JAR}"
   # Keep this in sync with the actual command below.
-  echo java -ea -Xmx512m -Xbootclasspath/p:${JAVAC_JAR} -classpath ${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotator.Main "$@"
+  echo java -ea -Xmx512m -classpath ${JAVAC_JAR}:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotator.Main "$@"
   echo "--- end of insert-annotations-to-source debugging output"
 fi
 
 # Augment, don't replace, CLASSPATH, so as to find user files.
-# Can we can do without annotation-file-utilities.jar on bootclasspath?
-java -ea -Xmx512m -Xbootclasspath/p:${JAVAC_JAR} -classpath ${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotator.Main "$@"
+java -ea -Xmx512m -classpath ${JAVAC_JAR}:${ANNOTATION_FILE_UTILS}:${CLASSPATH} annotator.Main "$@"

--- a/annotation-file-utilities/scripts/insert-annotations-to-source.bat
+++ b/annotation-file-utilities/scripts/insert-annotations-to-source.bat
@@ -5,9 +5,8 @@
 set ANNOTATION_FILE_UTILS=%~d0
 set ANNOTATION_FILE_UTILS=%ANNOTATION_FILE_UTILS%%~p0
 set ANNOTATION_FILE_UTILS=%ANNOTATION_FILE_UTILS%\..\annotation-file-utilities.jar
-:: Contains new version of java.lang.annotation.ElementType.
 set JAVAC_JAR=%~d0
 set JAVAC_JAR=%ANNOTATION_FILE_UTILS%%~p0
 set JAVAC_JAR=%JAVAC_JAR%..\..\..\jsr308-langtools\dist\lib\javac.jar
 
-java -ea "-Xbootclasspath/p:%ANNOTATION_FILE_UTILS%;%JAVAC_JAR%" -Xbootclasspath/p:"%ANNOTATION_FILE_UTILS%" -cp "%ANNOTATION_FILE_UTILS%;%CLASSPATH%" annotator.Main %*
+java -ea -cp "%JAVAC_JAR%;%ANNOTATION_FILE_UTILS%;%CLASSPATH%" annotator.Main %*

--- a/annotation-file-utilities/scripts/insert-annotations.bat
+++ b/annotation-file-utilities/scripts/insert-annotations.bat
@@ -6,9 +6,8 @@
 set ANNOTATION_FILE_UTILS=%~d0
 set ANNOTATION_FILE_UTILS=%ANNOTATION_FILE_UTILS%%~p0
 set ANNOTATION_FILE_UTILS=%ANNOTATION_FILE_UTILS%\..\annotation-file-utilities.jar
-:: Contains new version of java.lang.annotation.ElementType.
 set JAVAC_JAR=%~d0
 set JAVAC_JAR=%ANNOTATION_FILE_UTILS%%~p0
 set JAVAC_JAR=%JAVAC_JAR%..\..\..\jsr308-langtools\dist\lib\javac.jar
 
-java -ea "-Xbootclasspath/p:%ANNOTATION_FILE_UTILS%;%JAVAC_JAR%" -cp "%ANNOTATION_FILE_UTILS%;%CLASSPATH%" annotations.io.classfile.ClassFileWriter %*
+java -ea -cp "%JAVAC_JAR%;%ANNOTATION_FILE_UTILS%;%CLASSPATH%" annotations.io.classfile.ClassFileWriter %*

--- a/annotation-file-utilities/tests/Makefile
+++ b/annotation-file-utilities/tests/Makefile
@@ -75,15 +75,10 @@ bin/annotator/tests/%.class: %.java
 	$(XJAVAC) -Xlint:-options -g -cp bin:../annotation-file-utilities.jar -d bin -sourcepath . $*.java
 
 # Actually runs the annotator to create the annotated java file.
-# We are required to put annotation-file-utilities.jar (and ../bin) on the
-# bootclasspath so that the JSR 308 javac classes bundled therein are found
-# before the stock javac classes that the Mac OS includes on the bootclasspath
-# (other platforms do not make such inclusions)
 .PRECIOUS: %.output
 %.output: %.jaif %.java bin/annotator/tests/%.class ../lib/plume-core.jar ../bin ../annotation-file-utilities.jar
 	$(JAVA) \
-        -Xbootclasspath/p:../bin:../annotation-file-utilities.jar \
-        -cp bin \
+	-cp ../bin:../annotation-file-utilities.jar:bin \
 	annotator.Main \
 	${DEBUG} \
 	--abbreviate=false \

--- a/annotation-file-utilities/tests/abbreviated/Makefile
+++ b/annotation-file-utilities/tests/abbreviated/Makefile
@@ -57,14 +57,9 @@ compile : $(SRC)
 	$(JAVAC) -g -cp bin:../../bin -d bin -sourcepath . $(SRC)
 
 # Actually runs the annotator to create the annotated java file.
-# We are required to put annotation-file-utilities.jar (and ../bin) on the
-# bootclasspath so that the JSR 308 javac classes bundled therein are found
-# before the stock javac classes that the Mac OS includes on the bootclasspath
-# (other platforms do not make such inclusions)
 output: compile $(JAIF) ../../bin $(AFU_JARS)
 	$(JAVA) \
-        -Xbootclasspath/p:../../bin:../../annotation-file-utilities.jar \
-	-cp bin \
+	-cp ../../bin:../../annotation-file-utilities.jar:bin \
 	annotator.Main \
 	${DEBUG} \
 	--abbreviate=true \

--- a/annotation-file-utilities/tests/source-extension/Makefile
+++ b/annotation-file-utilities/tests/source-extension/Makefile
@@ -60,15 +60,10 @@ bin/annotator/tests/%.class: %.java
 	$(JAVAC) -g -cp bin:../../bin -d bin -sourcepath . $<
 
 # Actually runs the annotator to create the annotated java file.
-# We are required to put annotation-file-utilities.jar (and ../bin) on the
-# bootclasspath so that the JSR 308 javac classes bundled therein are found
-# before the stock javac classes that the Mac OS includes on the bootclasspath
-# (other platforms do not make such inclusions)
 .PRECIOUS: %.output
 %.output: %.jaif %.java bin/annotator/tests/%.class ../../lib/plume-core.jar ../../bin ../../annotation-file-utilities.jar
 	$(JAVA) \
-        -Xbootclasspath/p:../../bin:../../annotation-file-utilities.jar \
-	-cp bin \
+	-cp ../../bin:../../annotation-file-utilities.jar:bin \
 	annotator.Main \
 	${DEBUG} \
 	--abbreviate=false \

--- a/scene-lib/anncat
+++ b/scene-lib/anncat
@@ -5,8 +5,8 @@
 SCENE_LIB=$(dirname $0)
 WORKSPACE=$SCENE_LIB/..
 ASMX=$WORKSPACE/asmx
-# Contains new version of java.lang.annotation.ElementType.
+
 JAVAC_JAR=${JAVAC_JAR:-${SCENE_LIB}/../../jsr308-langtools/dist/lib/javac.jar}
 
-export CLASSPATH=$SCENE_LIB/bin:$ASMX/bin:$WORKSPACE/annotation-file-utilities/lib/plume-core.jar:$CLASSPATH
-java -Xbootclasspath/p:${JAVAC_JAR} annotations.tools.Anncat "$@"
+export CLASSPATH=${JAVAC_JAR}:$SCENE_LIB/bin:$ASMX/bin:$WORKSPACE/annotation-file-utilities/lib/plume-core.jar:$CLASSPATH
+java annotations.tools.Anncat "$@"

--- a/scene-lib/build.xml
+++ b/scene-lib/build.xml
@@ -179,7 +179,6 @@
                executable="${annotations-compiler}/dist/bin/javac">
             <src refid="sourcepath"/>
             <src refid="testpath"/>
-            <compilerarg value="-Xbootclasspath/p:${toString:libpath}"/>
             <!-- To prevent a cyclic dependency with the Checker
                  Framework, ignore type annotations in comments here.
                  A separate target could be added to check the qualifiers
@@ -216,7 +215,6 @@
     <target name="test-scene-lib" depends="init, bin">
         <mkdir dir="reports"/>
         <junit printsummary="withOutAndErr" showoutput="true" fork="yes" dir="." haltonerror="yes" haltonfailure="yes">
-            <jvmarg value="-Xbootclasspath/p:${toString:libpath}"/>
             <classpath refid="libpath"/>
             <formatter type="plain"/>
             <test name="annotations.tests.executable.TestSceneLib" todir="reports"/>
@@ -229,7 +227,6 @@
     <target name="test-classfile" depends="init, bin">
         <mkdir dir="reports"/>
         <junit printsummary="withOutAndErr" showoutput="true" fork="yes" dir="." haltonerror="yes" haltonfailure="yes">
-            <jvmarg value="-Xbootclasspath/p:${toString:libpath}"/>
             <classpath refid="libpath"/>
             <formatter type="plain"/>
             <test name="annotations.tests.classfile.AnnotationsTest" todir="reports"/>
@@ -303,6 +300,7 @@
                 destdir="javadoc"
                 access="public"
                 noqualifier="annotations:annotations.el:annotations.field:annotations.io:annotations.io.classfile:annotations.util:annotations.util.coll:java.lang"
+		failonerror="true"
                 />
     </target>
 

--- a/scene-lib/src/annotations/field/ArrayAFT.java
+++ b/scene-lib/src/annotations/field/ArrayAFT.java
@@ -24,7 +24,6 @@ public final class ArrayAFT extends AnnotationFieldType {
      * (see {@link annotations.AnnotationBuilder#addEmptyArrayField}).
      */
     public ArrayAFT(ScalarAFT elementType) {
-        assert elementType != null;
         this.elementType = elementType;
     }
 

--- a/scene-lib/src/annotations/io/ASTPath.java
+++ b/scene-lib/src/annotations/io/ASTPath.java
@@ -141,7 +141,7 @@ implements Comparable<ASTPath>, Iterable<ASTPath.ASTEntry> {
     /**
      * Constructs a new AST entry, without an argument.
      *
-     * See {@link #ASTPath.ASTEntry(Tree.Kind, String, Integer)} for an example of the parameters.
+     * See {@link #ASTEntry(Tree.Kind, String, Integer)} for an example of the parameters.
      *
      * @param treeKind the kind of this AST entry
      * @param childSelector the child selector to this AST entry


### PR DESCRIPTION
As we no longer support Java 7, we don't need to change the bootclasspath.