### PR TITLE
Extract annotations on method type parameter declarations.

### DIFF
--- a/scene-lib/src/scenelib/annotations/io/classfile/ClassAnnotationSceneReader.java
+++ b/scene-lib/src/scenelib/annotations/io/classfile/ClassAnnotationSceneReader.java
@@ -877,8 +877,16 @@ extends EmptyVisitor {
       }
     }
 
+      /**
+       * Creates the method type parameter bound annotation on aMethod.
+       */
+      private void handleMethodTypeParameter(AMethod aMethod) {
+          aMethod.bounds.vivify(makeTypeParameterLocation())
+                  .tlAnnotationsHere.add(makeAnnotation());
+      }
+
     /**
-     * Creates the class type parameter bound annotation on aClass.
+     * Creates the method type parameter bound annotation on aMethod.
      */
     private void handleMethodTypeParameterBound(AMethod aMethod) {
       if (xLocationsArgs.isEmpty()) {
@@ -948,10 +956,6 @@ extends EmptyVisitor {
             .innerTypes.vivify(makeInnerTypeLocation())
             .tlAnnotationsHere.add(makeAnnotation());
       }
-    }
-
-    private void handleMethodTypeParameter(AMethod aMethod) {
-      // TODO: throw new RuntimeException("METHOD_TYPE_PARAMETER: to do");
     }
 
     /**


### PR DESCRIPTION
I was able to use this branch to create a version of jdk8.jar with the correct annotations on method type parameters.

I don't know where or if we test extract-annotations, so I didn't add a test.