### PR TITLE
fixed a typo

### DIFF
--- a/scene-lib/src/scenelib/annotations/el/ATypeElementWithType.java
+++ b/scene-lib/src/scenelib/annotations/el/ATypeElementWithType.java
@@ -80,7 +80,7 @@ public class ATypeElementWithType extends ATypeElement {
             && ((ATypeElementWithType) o).equals(this);
     }
 
-    public boolean equalsTypeElementWithType(ATypeElementWithType o) {
+    public boolean equals(ATypeElementWithType o) {
         return super.equals(o) && o.type.equals(type);
     }
 


### PR DESCRIPTION
Wrong method name causes ATypeElementWithType.equal to return wrong values.