### PR TITLE
fix eclipse classpath file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ annotation-file-utilities/tests/system-test/out4.class
 annotation-file-utilities/tests/system-test/out5.diff
 annotation-file-utilities/tests/system-test/out5.jaif
 
+# ignore symbolic link to JRE/lib/tools.jar and JRE/src.zip
+annotation-file-utilities/lib/tools.jar
+annotation-file-utilities/lib/src.zip
+
 asmx/output
 
 scene-lib/javadoc

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ annotation-file-utilities/tests/system-test/out4.class
 annotation-file-utilities/tests/system-test/out5.diff
 annotation-file-utilities/tests/system-test/out5.jaif
 
-# ignore symbolic link to JRE/lib/tools.jar and JRE/src.zip
+# ignore symbolic links to JDK files
 annotation-file-utilities/lib/tools.jar
 annotation-file-utilities/lib/src.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ annotation-file-utilities/tests/system-test/out5.jaif
 
 # ignore symbolic links to JDK files
 annotation-file-utilities/lib/tools.jar
-annotation-file-utilities/lib/src.zip
+annotation-file-utilities/lib/jdk-src.zip
 
 asmx/output
 

--- a/annotation-file-utilities/.classpath
+++ b/annotation-file-utilities/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="/asmx"/>
 	<classpathentry kind="src" path="/scene-lib"/>
-	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="lib/guava-20.0.jar"/>

--- a/annotation-file-utilities/.classpath
+++ b/annotation-file-utilities/.classpath
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="/asmx"/>
+	<classpathentry kind="src" path="/scene-lib"/>
+	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/asmx"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/scene-lib"/>
-	<classpathentry kind="lib" path="lib/guava-20.0.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="lib" path="lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="lib/bcel-util-1.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/options-1.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/plume-util-1.0.1.jar"/>

--- a/annotation-file-utilities/lib/README-eclipse
+++ b/annotation-file-utilities/lib/README-eclipse
@@ -26,14 +26,14 @@ chose to install your JDK.
 2) Creating symbolic links:
 
 Linux / Mac :
-ln -s <your/path/to/jre>/lib/tools.jar
-ln -s <your/path/to/jre>/src.zip
+ln -s <your/path/to/jdk>/lib/tools.jar
+ln -s <your/path/to/jdk>/src.zip jdk-src.zip
 
 Windows (NTFS file system) :
 In a command prompt with administrative priviliges, issue:
-mklink tools.jar <your\path\to\jre>\lib\tools.jar
-mklink src.zip <your\path\to\jre>\src.zip
+mklink tools.jar <your\path\to\jdk>\lib\tools.jar
+mklink jdk-src.zip <your\path\to\jdk>\src.zip
 
 Windows (other file systems) :
-copy <your\path\to\jre>\lib\tools.jar
-copy <your\path\to\jre>\src.zip
+copy <your\path\to\jdk>\lib\tools.jar
+copy <your\path\to\jdk>\src.zip jdk-src.zip

--- a/annotation-file-utilities/lib/README-eclipse
+++ b/annotation-file-utilities/lib/README-eclipse
@@ -1,0 +1,36 @@
+If you are developing annotation-tools or checker-framework using eclipse,
+you'll need to add symbolic links in this (annotation-file-utilities/lib)
+directory pointing to JRE tools.jar and src.zip
+
+1) Downloading JDK src.zip:
+
+Linux :
+sudo apt-get -qqy install openjdk-8-source
+then check that it exists in /usr/lib/jvm/java-8-openjdk-amd64
+
+Mac:
+src.zip should already be included in your java distribution if installed via
+brew, check that it exists in directory
+/Library/Java/JavaVirtualMachines/jdk1.8.0_<version>.jdk/Contents/Home
+
+Windows :
+re-run the JDK install wizard and in the custom setup panel, ensure
+"Source Code" is selected for installation.
+then check that it exists in C:\Program Files\Java\jdk1.8.0_181 or wherever you
+chose to install your JDK
+
+
+2) Creating symbolic links:
+
+Linux / Mac :
+ln -s <your/path/to/jre>/lib/tools.jar
+ln -s <your/path/to/jre>/src.zip
+
+Windows (NTFS file system) :
+In a command prompt with administrative priviliges, issue:
+mklink tools.jar <your\path\to\jre>\lib\tools.jar
+mklink src.zip <your\path\to\jre>\src.zip
+
+Windows (other file systems) :
+copy <your\path\to\jre>\lib\tools.jar 
+copy <your\path\to\jre>\src.zip

--- a/annotation-file-utilities/lib/README-eclipse
+++ b/annotation-file-utilities/lib/README-eclipse
@@ -1,6 +1,9 @@
-If you are developing annotation-tools or checker-framework using eclipse,
-you'll need to add symbolic links in this (annotation-file-utilities/lib)
-directory pointing to JRE tools.jar and src.zip
+If you are developing annotation-tools or checker-framework using Eclipse,
+you need to add symbolic links in this (annotation-file-utilities/lib)
+directory pointing to the JDK tools.jar and src.zip files.
+This is necessary to have access to javac and its source code, without
+having to edit the .classpath files (there is no way to refer to these
+files as part of the JRE_CONTAINER).
 
 1) Downloading JDK src.zip:
 
@@ -16,8 +19,8 @@ brew, check that it exists in directory
 Windows :
 re-run the JDK install wizard and in the custom setup panel, ensure
 "Source Code" is selected for installation.
-then check that it exists in C:\Program Files\Java\jdk1.8.0_181 or wherever you
-chose to install your JDK
+Then check that it exists in C:\Program Files\Java\jdk1.8.0_181 or wherever you
+chose to install your JDK.
 
 
 2) Creating symbolic links:

--- a/annotation-file-utilities/lib/README-eclipse
+++ b/annotation-file-utilities/lib/README-eclipse
@@ -32,5 +32,5 @@ mklink tools.jar <your\path\to\jre>\lib\tools.jar
 mklink src.zip <your\path\to\jre>\src.zip
 
 Windows (other file systems) :
-copy <your\path\to\jre>\lib\tools.jar 
+copy <your\path\to\jre>\lib\tools.jar
 copy <your\path\to\jre>\src.zip

--- a/asmx/.classpath
+++ b/asmx/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
+	<classpathentry kind="lib" path="/annotation-file-utilities/lib/tools.jar" sourcepath="/annotation-file-utilities/lib/src.zip" exported="true"/>
 	<classpathentry kind="output" path="output/build"/>
 </classpath>

--- a/asmx/.classpath
+++ b/asmx/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
-	<classpathentry kind="lib" path="/annotation-file-utilities/lib/tools.jar" sourcepath="/annotation-file-utilities/lib/src.zip" exported="true"/>
+	<classpathentry kind="lib" path="/annotation-file-utilities/lib/tools.jar" sourcepath="/annotation-file-utilities/lib/jdk-src.zip" exported="true"/>
 	<classpathentry kind="output" path="output/build"/>
 </classpath>

--- a/asmx/.classpath
+++ b/asmx/.classpath
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
+	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
+	<classpathentry kind="output" path="output/build"/>
 </classpath>

--- a/scene-lib/.classpath
+++ b/scene-lib/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="/asmx"/>
-	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/guava-20.0.jar"/>

--- a/scene-lib/.classpath
+++ b/scene-lib/.classpath
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="/asmx"/>
+	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="junit.jar"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/asmx"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/bcel-util-1.0.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/options-1.0.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/plume-util-1.0.1.jar"/>
-	<classpathentry kind="output" path="bin"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/checker-qual-2.5.4.jar"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Fix eclipse import issues by adding dependency to `tools.jar` and `src.zip` from the JRE, which are symlinked in `AFU/lib`.

This PR should be merged at the same time as https://github.com/typetools/checker-framework/pull/2149

Fix eclipse output folder for `asmx` project to correspond with its build file

Also reordered entries so that source dependencies appear before configurations, libraries, and outputs in the xml files