### PR TITLE
update eclipse project classpaths

### DIFF
--- a/annotation-file-utilities/.classpath
+++ b/annotation-file-utilities/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="/asmx"/>
+	<classpathentry kind="src" path="/scene-lib"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/asmx"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/scene-lib"/>
-	<classpathentry kind="lib" path="lib/guava-20.0.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="lib" path="lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="lib/bcel-util-1.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/options-1.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/plume-util-1.0.1.jar"/>

--- a/annotation-file-utilities/.classpath
+++ b/annotation-file-utilities/.classpath
@@ -5,10 +5,10 @@
 	<classpathentry kind="src" path="/scene-lib"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="lib" path="lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="lib/bcel-util-1.0.0.jar"/>
+	<classpathentry kind="lib" path="lib/checker-qual-2.5.4.jar"/>
+	<classpathentry kind="lib" path="lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="lib/options-1.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/plume-util-1.0.1.jar"/>
-	<classpathentry kind="lib" path="lib/checker-qual-2.5.4.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/asmx/.classpath
+++ b/asmx/.classpath
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
+    <classpathentry kind="src" path="/jsr308-langtools" exported="true" />
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+    <classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/asmx/.classpath
+++ b/asmx/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-    <classpathentry kind="src" path="/jsr308-langtools" exported="true" />
+	<classpathentry kind="src" path="/jsr308-langtools" exported="true" />
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-    <classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
+	<classpathentry kind="lib" path="config/ow_util_ant_tasks.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/scene-lib/.classpath
+++ b/scene-lib/.classpath
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="/asmx"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="junit.jar"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/asmx"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/bcel-util-1.0.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/options-1.0.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/plume-util-1.0.1.jar"/>
-	<classpathentry kind="output" path="bin"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/checker-qual-2.5.4.jar"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/scene-lib/.classpath
+++ b/scene-lib/.classpath
@@ -4,10 +4,10 @@
 	<classpathentry kind="src" path="/asmx"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="lib" path="/annotation-file-utilities/lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/bcel-util-1.0.0.jar"/>
+	<classpathentry kind="lib" path="/annotation-file-utilities/lib/checker-qual-2.5.4.jar"/>
+	<classpathentry kind="lib" path="/annotation-file-utilities/lib/guava-20.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/options-1.0.0.jar"/>
 	<classpathentry kind="lib" path="/annotation-file-utilities/lib/plume-util-1.0.1.jar"/>
-	<classpathentry kind="lib" path="/annotation-file-utilities/lib/checker-qual-2.5.4.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
sort entries by src / con / lib / output, and by names within each kind

for `scene-lib`, use eclipse's Junit 4 library instead of the junit.jar