### PR TITLE
Remove error causing square bracket and quotes + Some formatting in `--help` message

### DIFF
--- a/annotation-file-utilities/scripts/extract-annotations
+++ b/annotation-file-utilities/scripts/extract-annotations
@@ -10,7 +10,7 @@
 # provided.
 DEBUG=0
 CLASSPATH=${CLASSPATH}
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   case "$1" in
     --debug-script)
       # Debug this script

--- a/annotation-file-utilities/scripts/extract-annotations
+++ b/annotation-file-utilities/scripts/extract-annotations
@@ -10,7 +10,7 @@
 # provided.
 DEBUG=0
 CLASSPATH=${CLASSPATH}
-while [ $# -gt 0 ]; do
+while [ "$#" -gt 0 ]; do
   case "$1" in
     --debug-script)
       # Debug this script

--- a/annotation-file-utilities/scripts/extract-annotations
+++ b/annotation-file-utilities/scripts/extract-annotations
@@ -17,7 +17,7 @@ while [ $# -gt 0 ]; do
       DEBUG=1
       shift
       ;;
-    -cp|-classpath)
+    -cp | -classpath)
       # Set the classpath
       CLASSPATH=$2
       shift 2

--- a/scene-lib/src/scenelib/annotations/io/classfile/ClassFileReader.java
+++ b/scene-lib/src/scenelib/annotations/io/classfile/ClassFileReader.java
@@ -46,6 +46,7 @@ public class ClassFileReader {
     + "the command line.  A few options are available only when invoked via the"
     + linesep
     + "script extract-annotations, not when invoked as a Java program:"
+    + linesep
     + "  --debug-script                       - make the extract-annotations script output debugging information"
     + linesep
     + "  -cp <classpath>                      - use the given classpath instead of the CLASSPATH environment variable"


### PR DESCRIPTION
There is an extra square bracket that was causing an error on execution of `extract-annotations`

```
/mnt/Work/Checker_Framework/annotation-tools/annotation-file-utilities/scripts/extract-annotations: 13: /mnt/Work/Checker_Framework/annotation-tools/annotation-file-utilities/scripts/extract-annotations: [[: not found
```