### PR TITLE
 Changes to src resulting from running -Xlint:unchecked.

### DIFF
--- a/scene-lib/src/scenelib/annotations/el/AnnotationDef.java
+++ b/scene-lib/src/scenelib/annotations/el/AnnotationDef.java
@@ -168,7 +168,12 @@ public final class AnnotationDef extends AElement {
      */
     public List<String> targets() {
         Annotation target = target();
-        return (target == null) ? null : (List<String>) target.getFieldValue("value");
+        if(target == null) {
+            return null;
+        }
+        @SuppressWarnings("unchecked")
+        List<String> fieldValue = (List<String>) target.getFieldValue("value");
+        return fieldValue;
     }
 
     /**

--- a/scene-lib/src/scenelib/annotations/el/AnnotationDef.java
+++ b/scene-lib/src/scenelib/annotations/el/AnnotationDef.java
@@ -168,7 +168,7 @@ public final class AnnotationDef extends AElement {
      */
     public List<String> targets() {
         Annotation target = target();
-        if(target == null) {
+        if (target == null) {
             return null;
         }
         @SuppressWarnings("unchecked")

--- a/scene-lib/src/scenelib/annotations/el/DefCollector.java
+++ b/scene-lib/src/scenelib/annotations/el/DefCollector.java
@@ -149,7 +149,7 @@ public abstract class DefCollector {
             collect(b);
         }
         collect((ADeclaration) m);
-        collect((ATypeElement) m.returnType);
+        collect(m.returnType);
         collect(m.receiver);
         for (AElement p : m.parameters.values()) {
             collect(p);

--- a/scene-lib/src/scenelib/annotations/field/AnnotationFieldType.java
+++ b/scene-lib/src/scenelib/annotations/field/AnnotationFieldType.java
@@ -30,6 +30,7 @@ public abstract class AnnotationFieldType extends EqualByStringRepresentation {
     // TODO: add a cache?
     public static AnnotationFieldType fromClass(Class<?> c, Map<String,AnnotationDef> adefs) {
         if (c.isAnnotation()) {
+            @SuppressWarnings("unchecked")
             Class<? extends java.lang.annotation.Annotation> cAnno
                 = (Class<? extends java.lang.annotation.Annotation>) c;
             return new AnnotationAFT(AnnotationDef.fromClass(cAnno, adefs));

--- a/scene-lib/src/scenelib/annotations/field/ArrayAFT.java
+++ b/scene-lib/src/scenelib/annotations/field/ArrayAFT.java
@@ -43,7 +43,7 @@ public final class ArrayAFT extends AnnotationFieldType {
     @Override
     public  String toString() {
         return (elementType == null ? "unknown" :
-            ((ScalarAFT) elementType).toString()) + "[]";
+            elementType.toString()) + "[]";
     }
 
     @Override

--- a/scene-lib/src/scenelib/annotations/io/ASTIndex.java
+++ b/scene-lib/src/scenelib/annotations/io/ASTIndex.java
@@ -426,7 +426,7 @@ public class ASTIndex extends WrapperMap<Tree, ASTRecord> {
             counters.push(++i);
             className = rec.className + "$" + i;
           } else {
-            ClassSymbol sym = ((JCTree.JCClassDecl) classBody).sym;
+            ClassSymbol sym = classBody.sym;
             String s = sym == null ? "" : sym.toString();
             if (s.startsWith("<anonymous ")) {
               int i = counters.pop();
@@ -607,7 +607,7 @@ public class ASTIndex extends WrapperMap<Tree, ASTRecord> {
         Kind kind = node.getKind();
         if (rec.methodName == null) {  // member field
           rec = new ASTRecord(cut, rec.className, rec.methodName,
-              ((VariableTree) node).getName().toString(), rec.astPath);
+              node.getName().toString(), rec.astPath);
         }
         save(node.getType(), rec, kind, ASTPath.TYPE);
         save(node.getInitializer(), rec, kind, ASTPath.INITIALIZER);

--- a/scene-lib/src/scenelib/annotations/io/IndexFileParser.java
+++ b/scene-lib/src/scenelib/annotations/io/IndexFileParser.java
@@ -434,7 +434,7 @@ public final class IndexFileParser {
             // interested in this annotation,
             // so should be interested in subannotations
             assert ab != null;
-            AnnotationBuilder ab2 = (AnnotationBuilder) ab;
+            AnnotationBuilder ab2 = ab;
             Annotation suba = parseAnnotationBody(d, ab2);
             assert aft.isValidValue(suba);
             return suba;
@@ -485,7 +485,7 @@ public final class IndexFileParser {
             throw new ParseException("The annotation type " + d.name
                 + " has no field called " + fieldName);
         }
-        AnnotationFieldType aft = (AnnotationFieldType) aft1;
+        AnnotationFieldType aft = aft1;
         if (aft instanceof ArrayAFT) {
             ArrayAFT aaft = (ArrayAFT) aft;
             if (aaft.elementType == null) {
@@ -609,7 +609,7 @@ public final class IndexFileParser {
             if (ad == null) {
                 throw new ParseException("Annotation type " + name + " used as a field before it is defined");
             }
-            return new AnnotationAFT((AnnotationDef) ad);
+            return new AnnotationAFT(ad);
         } else {
             throw new ParseException(
                     "Expected the beginning of an annotation field type: "

--- a/scene-lib/src/scenelib/annotations/io/ParseException.java
+++ b/scene-lib/src/scenelib/annotations/io/ParseException.java
@@ -11,6 +11,7 @@ package scenelib.annotations.io;
  * isn't very good; in particular, it sometimes says "expected A, B or C"
  * when there are legal tokens other than A, B, and C.
  */
+@SuppressWarnings("serial")
 public final class ParseException extends Exception {
 
     public ParseException() {

--- a/scene-lib/src/scenelib/annotations/io/classfile/ClassAnnotationSceneWriter.java
+++ b/scene-lib/src/scenelib/annotations/io/classfile/ClassAnnotationSceneWriter.java
@@ -373,7 +373,7 @@ public class ClassAnnotationSceneWriter extends ClassAdapter {
       AnnotationFieldType aft = a.def().fieldTypes.get(fieldName);
       if (value instanceof Annotation) {
         AnnotationVisitor nav = av.visitAnnotation(fieldName, classDescToName(a.def().name));
-        visitFields(nav, (Annotation) a);
+        visitFields(nav, a);
         nav.visitEnd();
       } else if (value instanceof List) {
         // In order to visit an array, the AnnotationVisitor returned by


### PR DESCRIPTION
Can't add -Xlint:unchecked to the build script without also adding it to compiling the classes that are used for testing inserting annotations.