### PR TITLE
Print longs into .jaif files correctly

### DIFF
--- a/scene-lib/src/scenelib/annotations/io/IndexFileWriter.java
+++ b/scene-lib/src/scenelib/annotations/io/IndexFileWriter.java
@@ -123,6 +123,8 @@ public final class IndexFileWriter {
             pw.print(aft.format(o));
         } else if (aft instanceof BasicAFT && o instanceof String) {
             pw.print(Strings.escape((String) o));
+        } else if (aft instanceof BasicAFT && o instanceof Long) {
+            pw.print(o.toString() + "L");
         } else {
             pw.print(o.toString());
         }


### PR DESCRIPTION
On [this PR](https://github.com/typetools/checker-framework/pull/2871), @mernst asked that I transplant a fix to a similar bug in stub-based whole-program-inference into the .jaif writer in the Annotation File Utilities.

The bug is that the printer prints long literals that appear as arguments to annotations as integers; that is, without the `L` at the end. That causes them to be invalid Java syntax if they're larger than `Integer.MAX_VALUE` (or smaller than the minimum), which makes the .jaif file/stub file unparseable.