### PR TITLE
Correct checker-qual dependency

### DIFF
--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -53,10 +53,15 @@ dependencies {
     implementation 'org.plumelib:options:1.0.4'
     implementation 'org.plumelib:plume-util:1.1.4'
     implementation 'org.plumelib:reflection-util:0.2.2'
-    implementation 'com.google.guava:guava:28.2-jre'
+    // Annotations in checker-qual.jar are used, but no checkers are (currently) run on the code.
+    compileOnly 'org.checkerframework:checker-qual:3.3.0'
+    implementation ('com.google.guava:guava:28.2-jre') {
+        exclude group: 'org.checkerframework'
+    }
     implementation files('../asmx/bin/')
 
     testImplementation group: 'junit', name: 'junit', version: '4.13'
+    testImplementation 'org.checkerframework:checker-qual:3.3.0'
 }
 
 task compileAsmx(type: Exec, group: 'Build') {

--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     // Annotations in checker-qual.jar are used, but no checkers are (currently) run on the code.
     compileOnly 'org.checkerframework:checker-qual:3.3.0'
     implementation ('com.google.guava:guava:28.2-jre') {
-        // So long a guava only uses annotations from checker-qual, excluding it should not cause problems.
+        // So long as Guava only uses annotations from checker-qual, excluding it should not cause problems.
         exclude group: 'org.checkerframework'
     }
     implementation files('../asmx/bin/')

--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     // Annotations in checker-qual.jar are used, but no checkers are (currently) run on the code.
     compileOnly 'org.checkerframework:checker-qual:3.3.0'
     implementation ('com.google.guava:guava:28.2-jre') {
+        // So long a guava only uses annotations from checker-qual, excluding it should not cause problems.
         exclude group: 'org.checkerframework'
     }
     implementation files('../asmx/bin/')

--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'org.plumelib:options:1.0.4'
     implementation 'org.plumelib:plume-util:1.1.4'
     implementation 'org.plumelib:reflection-util:0.2.2'
-    compileOnly 'org.checkerframework:checker-qual:3.2.0'
     implementation 'com.google.guava:guava:28.2-jre'
     implementation files('../asmx/bin/')
 


### PR DESCRIPTION
Use the latest version of checker-qual.jar rather than what ever is included in the Guava jar.