### PR TITLE
Show classpath

### DIFF
--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -79,7 +79,6 @@ dependencies {
         exclude group: 'org.checkerframework'
     }
     implementation 'org.ow2.asm:asm:9.2'
-    implementation 'io.github.classgraph:classgraph:4.8.117'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.checkerframework:checker-qual:3.18.0'

--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -79,6 +79,7 @@ dependencies {
         exclude group: 'org.checkerframework'
     }
     implementation 'org.ow2.asm:asm:9.2'
+    implementation 'io.github.classgraph:classgraph:4.8.117'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.checkerframework:checker-qual:3.18.0'

--- a/annotation-file-utilities/src/annotator/specification/IndexFileSpecification.java
+++ b/annotation-file-utilities/src/annotator/specification/IndexFileSpecification.java
@@ -15,9 +15,7 @@ import annotator.scanner.MethodOffsetClassVisitor;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.sun.source.tree.Tree;
-import io.github.classgraph.ClassGraph;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -28,6 +26,7 @@ import org.checkerframework.checker.signature.qual.ClassGetName;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
+import org.plumelib.reflection.ReflectionPlume;
 import org.plumelib.util.FileIOException;
 import org.plumelib.util.Pair;
 import scenelib.annotations.Annotation;
@@ -219,9 +218,8 @@ public class IndexFileSpecification {
         System.out.println(
             "Warning: IndexFileSpecification did not find classfile for: " + className);
         System.out.println("The classpath is:");
-        for (URI uri : new ClassGraph().getClasspathURIs()) {
-          System.out.println("  " + uri);
-        }
+        System.out.println(ReflectionPlume.classpathToString());
+        // org.plumelib.util.SystemPlume.sleep(100);
         // throw new RuntimeException("IndexFileSpecification.parseClass", e);
       } catch (RuntimeException e) {
         System.err.println("IndexFileSpecification had a problem reading class: " + className);

--- a/annotation-file-utilities/src/annotator/specification/IndexFileSpecification.java
+++ b/annotation-file-utilities/src/annotator/specification/IndexFileSpecification.java
@@ -15,7 +15,9 @@ import annotator.scanner.MethodOffsetClassVisitor;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.sun.source.tree.Tree;
+import io.github.classgraph.ClassGraph;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -216,7 +218,11 @@ public class IndexFileSpecification {
         // https://github.com/typetools/annotation-tools/issues/34 .)
         System.out.println(
             "Warning: IndexFileSpecification did not find classfile for: " + className);
-        // throw new RuntimeException("IndexFileSpecification.parseClass: " + e);
+        System.out.println("The classpath is:");
+        for (URI uri : new ClassGraph().getClasspathURIs()) {
+          System.out.println("  " + uri);
+        }
+        // throw new RuntimeException("IndexFileSpecification.parseClass", e);
       } catch (RuntimeException e) {
         System.err.println("IndexFileSpecification had a problem reading class: " + className);
         throw e;


### PR DESCRIPTION
This can make the output much more verbose, but it can also be helpful in debugging.
We could consider adding a command-line option to disable it, if verbosity is a problem.