### PR TITLE
Remove bcel-util dependency

### DIFF
--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -48,7 +48,6 @@ dependencies {
         implementation "com.google.errorprone:javac:$errorproneJavacVersion"
         errorproneJavac("com.google.errorprone:javac:$errorproneJavacVersion")
     }
-    implementation 'org.plumelib:bcel-util:1.1.16'
     if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
         implementation 'org.plumelib:options:1.0.6'
     } else {


### PR DESCRIPTION
This dependency isn't used. Fixes https://github.com/typetools/checker-framework/issues/5399.