### PR TITLE
Parse scientific notation.

### DIFF
--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/IndexFileParser.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/IndexFileParser.java
@@ -486,6 +486,16 @@ public final class IndexFileParser {
           if (type == long.class) {
             // permit optional 'L' character after long literals
             matchKeyword("L");
+          } else if (type == double.class) {
+            if (st.sval.matches("E[0-9]+")) {
+              val = Double.parseDouble(val + st.sval);
+              st.nextToken();
+            }
+          } else if (type == float.class) {
+            if (st.sval.matches("E[0-9]+")) {
+              val = Float.parseFloat(val + st.sval);
+              st.nextToken();
+            }
           }
         } else {
           throw new ParseException("Expected a number literal");

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/IndexFileParser.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/IndexFileParser.java
@@ -464,9 +464,10 @@ public final class IndexFileParser {
       } else {
         if (st.ttype == TT_NUMBER) {
           double n = st.nval;
+          st.nextToken();
           // TODO validate the literal better
           // HMMM StreamTokenizer can't handle all floating point
-          // numbers; in particular, scientific notation is a problem
+          // numbers.
           if (type == byte.class) {
             val = (byte) n;
           } else if (type == short.class) {
@@ -475,27 +476,22 @@ public final class IndexFileParser {
             val = (int) n;
           } else if (type == long.class) {
             val = (long) n;
-          } else if (type == float.class) {
-            val = (float) n;
-          } else if (type == double.class) {
-            val = n;
-          } else {
-            throw new AssertionError();
-          }
-          st.nextToken();
-          if (type == long.class) {
             // permit optional 'L' character after long literals
             matchKeyword("L");
-          } else if (type == double.class) {
-            if (st.sval.matches("E[0-9]+")) {
-              val = Double.parseDouble(val + st.sval);
-              st.nextToken();
-            }
           } else if (type == float.class) {
+            val = (float) n;
             if (st.sval.matches("E[0-9]+")) {
               val = Float.parseFloat(val + st.sval);
               st.nextToken();
             }
+          } else if (type == double.class) {
+            val = n;
+            if (st.sval.matches("E[0-9]+")) {
+              val = Double.parseDouble(val + st.sval);
+              st.nextToken();
+            }
+          } else {
+            throw new AssertionError();
           }
         } else {
           throw new ParseException("Expected a number literal");

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/IndexFileParser.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/IndexFileParser.java
@@ -465,9 +465,6 @@ public final class IndexFileParser {
         if (st.ttype == TT_NUMBER) {
           double n = st.nval;
           st.nextToken();
-          // TODO validate the literal better
-          // HMMM StreamTokenizer can't handle all floating point
-          // numbers.
           if (type == byte.class) {
             val = (byte) n;
           } else if (type == short.class) {
@@ -480,12 +477,14 @@ public final class IndexFileParser {
             matchKeyword("L");
           } else if (type == float.class) {
             val = (float) n;
+            // StreamTokenizer can't handle all floating point numbers, so parse them here.
             if (st.sval.matches("E[0-9]+")) {
               val = Float.parseFloat(val + st.sval);
               st.nextToken();
             }
           } else if (type == double.class) {
             val = n;
+            // StreamTokenizer can't handle all floating point numbers, so parse them here.
             if (st.sval.matches("E[0-9]+")) {
               val = Double.parseDouble(val + st.sval);
               st.nextToken();


### PR DESCRIPTION
Fixes the test failures in https://github.com/typetools/checker-framework/pull/5531. (Merge this pull request first.)