### PR TITLE
Use Error Prone 2.39.0

### DIFF
--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     exclude group: 'org.checkerframework'
   }
   implementation 'org.ow2.asm:asm:9.8'
-  ext.errorproneVersion = '2.38.0'
+  ext.errorproneVersion = '2.39.0'
   implementation "com.google.errorprone:error_prone_annotations:${errorproneVersion}"
   errorprone("com.google.errorprone:error_prone_core:${errorproneVersion}")
 

--- a/annotation-file-utilities/dev-scripts/test-misc.sh
+++ b/annotation-file-utilities/dev-scripts/test-misc.sh
@@ -33,7 +33,7 @@ status=0
 
 ## Code style and formatting
 JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
-if [ "${JAVA_VER}" != "8"] && [ "${JAVA_VER}" != "20" ] ; then
+if [ "${JAVA_VER}" != "8" ] && [ "${JAVA_VER}" != "20" ] ; then
   ./gradlew spotlessCheck --console=plain --warning-mode=all --no-daemon || status=1
 fi
 

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ASTPathCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ASTPathCriterion.java
@@ -187,7 +187,7 @@ public class ASTPathCriterion implements Criterion {
     }
 
     if ((i < actualPathLen && matchNext(next, actualPath.get(i)))
-        || (i <= actualPathLen && next.getKind() == Tree.Kind.NEW_ARRAY)) {
+        || (i <= actualPathLen && next instanceof NewArrayTree)) {
       return true;
     }
 
@@ -387,7 +387,7 @@ public class ASTPathCriterion implements Criterion {
             } else if (astNode.childSelectorIs(ASTPath.INITIALIZER)) {
               int i = 0;
               for (Tree member : clazz.getMembers()) {
-                if (member.getKind() == Tree.Kind.BLOCK && arg == i++) {
+                if (member instanceof BlockTree && arg == i++) {
                   return member;
                 }
               }
@@ -571,7 +571,7 @@ public class ASTPathCriterion implements Criterion {
               }
               typeTree = ((NewArrayTree) typeTree).getType();
               while (--arg > 0) {
-                if (typeTree.getKind() != Tree.Kind.ARRAY_TYPE) {
+                if (!(typeTree instanceof ArrayTypeTree)) {
                   return null;
                 }
                 typeTree = ((ArrayTypeTree) typeTree).getType();
@@ -783,12 +783,12 @@ public class ASTPathCriterion implements Criterion {
             && entry.getArgument() == -1
             && entry.childSelectorIs(ASTPath.BOUND);
       case TYPE_PARAMETER:
-        return node.getKind() == Tree.Kind.TYPE_PARAMETER
+        return node instanceof TypeParameterTree
             && ix == last
             && entry.getArgument() == 0
             && entry.childSelectorIs(ASTPath.BOUND);
       case METHOD: // nullary constructor? receiver?
-        if (node.getKind() != Tree.Kind.METHOD) {
+        if (!(node instanceof MethodTree)) {
           return false;
         }
         MethodTree method = (MethodTree) node;
@@ -821,7 +821,7 @@ public class ASTPathCriterion implements Criterion {
         }
         return false;
       case NEW_ARRAY:
-        if (node.getKind() != Tree.Kind.NEW_ARRAY) {
+        if (!(node instanceof NewArrayTree)) {
           return false;
         }
         NewArrayTree newArray = (NewArrayTree) node;
@@ -854,7 +854,7 @@ public class ASTPathCriterion implements Criterion {
   }
 
   private static int arrayDepth(Tree tree) {
-    if (tree.getKind() == Tree.Kind.NEW_ARRAY) {
+    if (tree instanceof NewArrayTree) {
       NewArrayTree newArray = (NewArrayTree) tree;
       Tree type = newArray.getType();
       if (type != null) {
@@ -880,9 +880,9 @@ public class ASTPathCriterion implements Criterion {
         }
       }
       return depth;
-    } else if (tree.getKind() == Tree.Kind.ANNOTATED_TYPE) {
+    } else if (tree instanceof AnnotatedTypeTree) {
       return arrayDepth(((AnnotatedTypeTree) tree).getUnderlyingType());
-    } else if (tree.getKind() == Tree.Kind.ARRAY_TYPE) {
+    } else if (tree instanceof ArrayTypeTree) {
       return 1 + arrayDepth(((ArrayTypeTree) tree).getType());
     } else {
       return 0;
@@ -1081,14 +1081,14 @@ public class ASTPathCriterion implements Criterion {
       // isWildcard(actualNode.getKind())
       // TODO: refactor GenericArrayLoc to use same code?
       Tree ancestor = actualPath.get(i - 1);
-      if (ancestor.getKind() == Tree.Kind.INSTANCE_OF) {
+      if (ancestor instanceof InstanceOfTree) {
         TreeFinder.warn.debug(
             "WARNING: wildcard bounds not allowed "
                 + "in 'instanceof' expression; skipping insertion%n");
         return false;
-      } else if (i > 1 && ancestor.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+      } else if (i > 1 && ancestor instanceof ParameterizedTypeTree) {
         ancestor = actualPath.get(i - 2);
-        if (ancestor.getKind() == Tree.Kind.ARRAY_TYPE) {
+        if (ancestor instanceof ArrayTypeTree) {
           TreeFinder.warn.debug(
               "WARNING: wildcard bounds not allowed "
                   + "in 'instanceof' expression; skipping insertion%n");

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ASTPathCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ASTPathCriterion.java
@@ -853,6 +853,12 @@ public class ASTPathCriterion implements Criterion {
     }
   }
 
+  /**
+   * Returns the array depth of the given tree.
+   *
+   * @param tree a tree
+   * @return the array depth of the given tree
+   */
   private static int arrayDepth(Tree tree) {
     if (tree instanceof NewArrayTree) {
       NewArrayTree newArray = (NewArrayTree) tree;

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/CallCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/CallCriterion.java
@@ -1,5 +1,6 @@
 package org.checkerframework.afu.annotator.find;
 
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.afu.annotator.scanner.MethodCallScanner;
@@ -31,7 +32,7 @@ public class CallCriterion implements Criterion {
 
     Tree leaf = path.getLeaf();
 
-    if (leaf.getKind() == Tree.Kind.METHOD_INVOCATION) {
+    if (leaf instanceof MethodInvocationTree) {
       int indexInSource = MethodCallScanner.indexOfMethodCallTree(path, leaf);
       boolean b;
       if (loc.isBytecodeOffset()) {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/CastCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/CastCriterion.java
@@ -1,6 +1,7 @@
 package org.checkerframework.afu.annotator.find;
 
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.afu.annotator.scanner.CastScanner;
 import org.checkerframework.afu.scenelib.el.RelativeLocation;
@@ -33,7 +34,7 @@ public class CastCriterion implements Criterion {
 
     Tree leaf = path.getLeaf();
 
-    if (leaf.getKind() == Tree.Kind.TYPE_CAST) {
+    if (leaf instanceof TypeCastTree) {
       int indexInSource = CastScanner.indexOfCastTree(path, leaf);
       boolean b;
       if (loc.isBytecodeOffset()) {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/Criteria.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/Criteria.java
@@ -1,6 +1,7 @@
 package org.checkerframework.afu.annotator.find;
 
 import com.google.errorprone.annotations.InlineMe;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import java.util.LinkedHashMap;
@@ -128,7 +129,7 @@ public final class Criteria {
     return (criteria.size() == 2
         && isOnMethod("<init>()V")
         && criteria.containsKey(Criterion.Kind.IN_CLASS)
-        && leaf.getKind() != Tree.Kind.METHOD);
+        && !(leaf instanceof MethodTree));
   }
 
   /**

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/FieldCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/FieldCriterion.java
@@ -1,6 +1,7 @@
 package org.checkerframework.afu.annotator.find;
 
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 
 public class FieldCriterion implements Criterion {
@@ -32,7 +33,7 @@ public class FieldCriterion implements Criterion {
 
   @Override
   public boolean isSatisfiedBy(TreePath path) {
-    if (path == null || (isDeclaration && path.getLeaf().getKind() != Tree.Kind.VARIABLE)) {
+    if (path == null || (isDeclaration && !(path.getLeaf() instanceof VariableTree))) {
       return false;
     }
 

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/GenericArrayLocationCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/GenericArrayLocationCriterion.java
@@ -2,11 +2,16 @@ package org.checkerframework.afu.annotator.find;
 
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.ArrayTypeTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.InstanceOfTree;
 import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
+import com.sun.source.tree.PrimitiveTypeTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeParameterTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.tree.WildcardTree;
 import com.sun.source.util.TreePath;
@@ -129,16 +134,16 @@ public class GenericArrayLocationCriterion implements Criterion {
     // a MEMBER_SELECT. This way we'll continue to traverse deeper in the tree
     // to find the correct MEMBER_SELECT.
     Tree child = null;
-    if (leaf.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+    if (leaf instanceof ParameterizedTypeTree) {
       child = ((ParameterizedTypeTree) leaf).getType();
-    } else if (leaf.getKind() == Tree.Kind.VARIABLE) {
+    } else if (leaf instanceof VariableTree) {
       child = ((VariableTree) leaf).getType();
-    } else if (leaf.getKind() == Tree.Kind.NEW_CLASS) {
+    } else if (leaf instanceof NewClassTree) {
       child = ((NewClassTree) leaf).getIdentifier();
-    } else if (leaf.getKind() == Tree.Kind.NEW_ARRAY && typePath != null) {
+    } else if (leaf instanceof NewArrayTree && typePath != null) {
       child = ((NewArrayTree) leaf).getType();
     }
-    if (child != null && child.getKind() == Tree.Kind.MEMBER_SELECT) {
+    if (child != null && child instanceof MemberSelectTree) {
       JCExpression exp = ((JCFieldAccess) child).getExpression();
       if ((exp.type != null && exp.type.getKind() == TypeKind.PACKAGE)
           || typePath == null
@@ -147,7 +152,7 @@ public class GenericArrayLocationCriterion implements Criterion {
       }
     }
 
-    if (leaf.getKind() == Tree.Kind.MEMBER_SELECT) {
+    if (leaf instanceof MemberSelectTree) {
       JCFieldAccess fieldAccess = (JCFieldAccess) leaf;
       if (isStatic(fieldAccess)) {
         // If this MEMBER_SELECT is for a static class...
@@ -167,7 +172,7 @@ public class GenericArrayLocationCriterion implements Criterion {
         }
       } else {
         JCExpression exp = fieldAccess.getExpression();
-        if (exp.getKind() == Tree.Kind.MEMBER_SELECT
+        if (exp instanceof MemberSelectTree
             && exp.type != null
             && exp.type.getKind() == TypeKind.PACKAGE) {
           if (typePath == null) {
@@ -192,19 +197,19 @@ public class GenericArrayLocationCriterion implements Criterion {
       Tree parent = path.getParentPath().getLeaf();
 
       boolean result =
-          ((leaf.getKind() == Tree.Kind.NEW_ARRAY)
-              || (leaf.getKind() == Tree.Kind.NEW_CLASS)
-              || (leaf.getKind() == Tree.Kind.ANNOTATED_TYPE
+          ((leaf instanceof NewArrayTree)
+              || (leaf instanceof NewClassTree)
+              || (leaf instanceof AnnotatedTypeTree
                   && isSatisfiedBy(
                       TreePath.getPath(path, ((AnnotatedTypeTree) leaf).getUnderlyingType())))
               || ((isGenericOrArray(leaf)
                       // or, it might be a raw type
-                      || (leaf.getKind() == Tree.Kind.IDENTIFIER) // IdentifierTree
-                      || (leaf.getKind() == Tree.Kind.METHOD) // MethodTree
-                      || (leaf.getKind() == Tree.Kind.TYPE_PARAMETER) // TypeParameterTree
+                      || (leaf instanceof IdentifierTree)
+                      || (leaf instanceof MethodTree)
+                      || (leaf instanceof TypeParameterTree)
                       // I don't know why a GenericArrayLocationCriterion
                       // is being created in this case, but it is.
-                      || (leaf.getKind() == Tree.Kind.PRIMITIVE_TYPE) // PrimitiveTypeTree
+                      || (leaf instanceof PrimitiveTypeTree)
                   // TODO: do we need wildcards here?
                   // || leaf instanceof WildcardTree
                   )
@@ -231,7 +236,7 @@ public class GenericArrayLocationCriterion implements Criterion {
     // place to insert the annotation this is the MEMBER_SELECT it should be
     // inserted on. So remove the rest of the MEMBER_SELECTs to get down to the
     // compound type and make sure the compound type location matches.
-    while (pathRemaining.getParentPath().getLeaf().getKind() == Tree.Kind.MEMBER_SELECT) {
+    while (pathRemaining.getParentPath().getLeaf() instanceof MemberSelectTree) {
       pathRemaining = pathRemaining.getParentPath();
     }
 
@@ -240,7 +245,7 @@ public class GenericArrayLocationCriterion implements Criterion {
     while (locationRemaining.size() != 0) {
       // annotating an inner type
       leaf = pathRemaining.getLeaf();
-      if ((leaf.getKind() == Tree.Kind.NEW_ARRAY) && containsOnlyArray(locationRemaining)) {
+      if ((leaf instanceof NewArrayTree) && containsOnlyArray(locationRemaining)) {
         if (debug) {
           System.out.println("Found a matching NEW_ARRAY");
         }
@@ -255,7 +260,7 @@ public class GenericArrayLocationCriterion implements Criterion {
       }
       Tree parent = parentPath.getLeaf();
 
-      if (parent.getKind() == Tree.Kind.ANNOTATED_TYPE) {
+      if (parent instanceof AnnotatedTypeTree) {
         // If the parent is an annotated type, we did not really go up a level.
         // Therefore, skip up one more level.
         parentPath = parentPath.getParentPath();
@@ -273,12 +278,12 @@ public class GenericArrayLocationCriterion implements Criterion {
 
       TypePathEntry loc = locationRemaining.get(locationRemaining.size() - 1);
       if (loc.step == TypePath.INNER_TYPE) {
-        if (leaf.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+        if (leaf instanceof ParameterizedTypeTree) {
           leaf = parent;
           parentPath = parentPath.getParentPath();
           parent = parentPath.getLeaf();
         }
-        if (leaf.getKind() != Tree.Kind.MEMBER_SELECT) {
+        if (!(leaf instanceof MemberSelectTree)) {
           return false;
         }
 
@@ -305,14 +310,14 @@ public class GenericArrayLocationCriterion implements Criterion {
         TreePath gpath = parentPath.getParentPath();
         if (gpath != null) { // TODO: skip over existing annotations?
           Tree gparent = gpath.getLeaf();
-          if (gparent.getKind() == Tree.Kind.INSTANCE_OF) {
+          if (gparent instanceof InstanceOfTree) {
             TreeFinder.warn.debug(
                 "WARNING: wildcard bounds not allowed "
                     + "in 'instanceof' expression; skipping insertion%n");
             return false;
-          } else if (gparent.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+          } else if (gparent instanceof ParameterizedTypeTree) {
             gpath = gpath.getParentPath();
-            if (gpath != null && gpath.getLeaf().getKind() == Tree.Kind.ARRAY_TYPE) {
+            if (gpath != null && gpath.getLeaf() instanceof ArrayTypeTree) {
               TreeFinder.warn.debug(
                   "WARNING: wildcard bounds not allowed "
                       + "in generic array type; skipping insertion%n");
@@ -321,7 +326,7 @@ public class GenericArrayLocationCriterion implements Criterion {
           }
         }
         locationRemaining.remove(locationRemaining.size() - 1);
-      } else if (parent.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+      } else if (parent instanceof ParameterizedTypeTree) {
         if (loc.step != TypePath.TYPE_ARGUMENT) {
           return false;
         }
@@ -332,7 +337,7 @@ public class GenericArrayLocationCriterion implements Criterion {
         Tree inner = ((ParameterizedTypeTree) parent).getType();
         int i = locationRemaining.size() - 1; // last valid type path index
         locationRemaining.remove(i--);
-        while (inner.getKind() == Tree.Kind.MEMBER_SELECT && !isStatic((JCFieldAccess) inner)) {
+        while (inner instanceof MemberSelectTree && !isStatic((JCFieldAccess) inner)) {
           // fieldAccess.type != null && fieldAccess.type.getKind() == TypeKind.DECLARED
           // && fieldAccess.type.tsym.isStatic()
           // TODO: check whether MEMBER_SELECT indicates inner or qualifier?
@@ -344,10 +349,10 @@ public class GenericArrayLocationCriterion implements Criterion {
           }
           locationRemaining.remove(i--);
           inner = ((MemberSelectTree) inner).getExpression();
-          if (inner.getKind() == Tree.Kind.ANNOTATED_TYPE) {
+          if (inner instanceof AnnotatedTypeTree) {
             inner = ((AnnotatedTypeTree) inner).getUnderlyingType();
           }
-          if (inner.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+          if (inner instanceof ParameterizedTypeTree) {
             inner = ((ParameterizedTypeTree) inner).getType();
           }
         }
@@ -362,19 +367,19 @@ public class GenericArrayLocationCriterion implements Criterion {
         boolean found = false;
         if (childTrees.size() > loc.argument) {
           Tree childi = childTrees.get(loc.argument);
-          if (childi.getKind() == Tree.Kind.ANNOTATED_TYPE) {
+          if (childi instanceof AnnotatedTypeTree) {
             childi = ((AnnotatedTypeTree) childi).getUnderlyingType();
           }
           if (childi == leaf) {
             for (TreePath outerPath = parentPath.getParentPath();
-                outerPath.getLeaf().getKind() == Tree.Kind.MEMBER_SELECT
+                outerPath.getLeaf() instanceof MemberSelectTree
                     && !isStatic((JCFieldAccess) outerPath.getLeaf());
                 outerPath = outerPath.getParentPath()) {
               outerPath = outerPath.getParentPath();
-              if (outerPath.getLeaf().getKind() == Tree.Kind.ANNOTATED_TYPE) {
+              if (outerPath.getLeaf() instanceof AnnotatedTypeTree) {
                 outerPath = outerPath.getParentPath();
               }
-              if (outerPath.getLeaf().getKind() != Tree.Kind.PARAMETERIZED_TYPE) {
+              if (!(outerPath.getLeaf() instanceof ParameterizedTypeTree)) {
                 break;
               }
               parentPath = outerPath;
@@ -428,7 +433,7 @@ public class GenericArrayLocationCriterion implements Criterion {
         } else {
           return false;
         }
-      } else if (parent.getKind() == Tree.Kind.ARRAY_TYPE) {
+      } else if (parent instanceof ArrayTypeTree) {
         if (loc.step != TypePath.ARRAY_ELEMENT) {
           return false;
         }
@@ -441,7 +446,7 @@ public class GenericArrayLocationCriterion implements Criterion {
         Tree elt = ((ArrayTypeTree) parent).getType();
         while (locationRemaining.size() > 0
             && locationRemaining.get(locationRemaining.size() - 1).step == TypePath.ARRAY_ELEMENT) {
-          if (elt.getKind() != Tree.Kind.ARRAY_TYPE) { // ArrayTypeTree
+          if (!(elt instanceof ArrayTypeTree)) {
             if (debug) {
               System.out.printf("Element: %s is not an ArrayTypeTree and therefore false.%n", elt);
             }
@@ -467,7 +472,7 @@ public class GenericArrayLocationCriterion implements Criterion {
         } else {
           return false;
         }
-      } else if (parent.getKind() == Tree.Kind.NEW_ARRAY) {
+      } else if (parent instanceof NewArrayTree) {
         if (loc.step != TypePath.ARRAY_ELEMENT) {
           return false;
         }
@@ -524,11 +529,11 @@ public class GenericArrayLocationCriterion implements Criterion {
   }
 
   private boolean isGenericOrArray(Tree t) {
-    return ((t.getKind() == Tree.Kind.PARAMETERIZED_TYPE)
-        || (t.getKind() == Tree.Kind.ARRAY_TYPE)
+    return ((t instanceof ParameterizedTypeTree)
+        || (t instanceof ArrayTypeTree)
         || (t.getKind() == Tree.Kind.EXTENDS_WILDCARD)
         || (t.getKind() == Tree.Kind.SUPER_WILDCARD)
-        || (t.getKind() == Tree.Kind.ANNOTATED_TYPE
+        || (t instanceof AnnotatedTypeTree
             && isGenericOrArray(((AnnotatedTypeTree) t).getUnderlyingType()))
     // Monolithic:  one node for entire "new".  So, handle specially.
     // || (t.getKind() == Tree.Kind.NEW_ARRAY)

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/GenericArrayLocationCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/GenericArrayLocationCriterion.java
@@ -528,6 +528,12 @@ public class GenericArrayLocationCriterion implements Criterion {
         && fieldAccess.type.tsym.isStatic();
   }
 
+  /**
+   * Returns true if the given tree is generic or an array.
+   *
+   * @param t a tree
+   * @return true if the given tree is generic or an array
+   */
   private boolean isGenericOrArray(Tree t) {
     return ((t instanceof ParameterizedTypeTree)
         || (t instanceof ArrayTypeTree)

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InClassCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InClassCriterion.java
@@ -1,5 +1,6 @@
 package org.checkerframework.afu.annotator.find;
 
+import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
@@ -120,7 +121,7 @@ public final class InClassCriterion implements Criterion {
         case INTERFACE:
         case ENUM:
         case ANNOTATION_TYPE:
-          if (i > 0 && trees.get(i - 1).getKind() == Tree.Kind.NEW_CLASS) {
+          if (i > 0 && trees.get(i - 1) instanceof NewClassTree) {
             // For an anonymous class, the CLASS tree is always directly inside of
             // a NEW_CLASS tree. If that's the case here then skip this iteration
             // since we've already looked at the new class tree in the previous
@@ -129,7 +130,7 @@ public final class InClassCriterion implements Criterion {
           }
           debug("InClassCriterion.isSatisfiedBy:%n  cname=%s%n  tree=%s%n", cname, tree);
 
-          if (i > 0 && trees.get(i - 1).getKind() == Tree.Kind.BLOCK) {
+          if (i > 0 && trees.get(i - 1) instanceof BlockTree) {
             // Section 14.3 of the JLS says "every local class declaration
             // statement is immediately contained by a block".
             checkLocal = true;

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InMethodCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InMethodCriterion.java
@@ -53,12 +53,12 @@ final class InMethodCriterion implements Criterion {
     TreePath childPath = null;
     do {
       Tree leaf = path.getLeaf();
-      if (leaf.getKind() == Tree.Kind.METHOD) {
+      if (leaf instanceof MethodTree) {
         boolean b = sigMethodCriterion.isSatisfiedBy(path);
         Criteria.dbug.debug("InMethodCriterion.isSatisfiedBy => %s%n", b);
         return b;
       }
-      if (leaf.getKind() == Tree.Kind.VARIABLE) { // variable declaration
+      if (leaf instanceof VariableTree) { // variable declaration
         VariableTree varDecl = (VariableTree) leaf;
         if (childPath != null && childPath.getLeaf() == varDecl.getInitializer()) {
           inDecl = true;

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InPackageCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InPackageCriterion.java
@@ -38,7 +38,7 @@ final class InPackageCriterion implements Criterion {
 
     do {
       Tree tree = path.getLeaf();
-      if (tree.getKind() == Tree.Kind.COMPILATION_UNIT) {
+      if (tree instanceof CompilationUnitTree) {
         CompilationUnitTree cu = (CompilationUnitTree) tree;
         ExpressionTree pn = cu.getPackageName();
         if (pn == null) {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/Insertions.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/Insertions.java
@@ -319,11 +319,10 @@ public class Insertions implements Iterable<Insertion> {
                   rec0 = rec.extend(Tree.Kind.NEW_ARRAY, ASTPath.TYPE, 0);
                 }
               } else if (node != null && !nins.getInnerTypeInsertions().isEmpty()) {
-                if (node.getKind() == Tree.Kind.IDENTIFIER) {
+                if (node instanceof IdentifierTree) {
                   node = ASTIndex.getNode(cut, rec.replacePath(p.getParentPath()));
                 }
-                if ((node.getKind() == Tree.Kind.NEW_ARRAY
-                        || node.getKind() == Tree.Kind.ARRAY_TYPE)
+                if ((node instanceof NewArrayTree || node instanceof ArrayTypeTree)
                     && !node.toString().startsWith("{")) {
                   rec = rec.replacePath(p.getParentPath());
 
@@ -372,7 +371,7 @@ public class Insertions implements Iterable<Insertion> {
           int d = newArrayInnerTypeDepth(p);
           if (d > 0) {
             ASTPath temp = p;
-            while (!temp.isEmpty() && (node == null || node.getKind() != Tree.Kind.NEW_ARRAY)) {
+            while (!temp.isEmpty() && (node == null || !(node instanceof NewArrayTree))) {
               // TODO: avoid repeating work of newArrayInnerTypeDepth()
               temp = temp.getParentPath();
               node = ASTIndex.getNode(cut, rec.replacePath(temp));
@@ -660,7 +659,7 @@ public class Insertions implements Iterable<Insertion> {
         rec = rec.extend(entry);
         kind = entry.getTreeKind();
 
-        while (node.getKind() == Tree.Kind.ANNOTATED_TYPE) { // skip
+        while (node instanceof AnnotatedTypeTree) {
           node = ((AnnotatedTypeTree) node).getUnderlyingType();
         }
         if (expectedDepth == 0) {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InstanceOfCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/InstanceOfCriterion.java
@@ -55,7 +55,7 @@ public class InstanceOfCriterion implements Criterion {
       return false;
     }
 
-    if (parent.getKind() == Tree.Kind.INSTANCE_OF) {
+    if (parent instanceof InstanceOfTree) {
       InstanceOfTree instanceOfTree = (InstanceOfTree) parent;
       if (leaf != instanceOfTree.getType()) {
         Criteria.dbug.debug("return: not type part of instanceof%n");

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/IntersectionTypeLocationCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/IntersectionTypeLocationCriterion.java
@@ -29,7 +29,7 @@ public class IntersectionTypeLocationCriterion implements Criterion {
     TreePath parentPath = path.getParentPath();
     if (parentPath != null) {
       Tree parent = parentPath.getLeaf();
-      if (parent.getKind() == Tree.Kind.INTERSECTION_TYPE) {
+      if (parent instanceof IntersectionTypeTree) {
         IntersectionTypeTree itt = (IntersectionTypeTree) parent;
         List<? extends Tree> bounds = itt.getBounds();
         Tree leaf = path.getLeaf();

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/IsSigMethodCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/IsSigMethodCriterion.java
@@ -288,7 +288,7 @@ public class IsSigMethodCriterion implements Criterion {
 
     Tree leaf = path.getLeaf();
 
-    if (leaf.getKind() != Tree.Kind.METHOD) {
+    if (!(leaf instanceof MethodTree)) {
       Criteria.dbug.debug(
           "IsSigMethodCriterion.isSatisfiedBy(%s) => false: not a METHOD tree%n",
           Main.leafString(path));
@@ -335,7 +335,7 @@ public class IsSigMethodCriterion implements Criterion {
       List<? extends Tree> paramBounds = param.getBounds();
       if (paramBounds != null && paramBounds.size() >= 1) {
         Tree boundZero = paramBounds.get(0);
-        if (boundZero.getKind() == Tree.Kind.ANNOTATED_TYPE) {
+        if (boundZero instanceof AnnotatedTypeTree) {
           boundZero = ((AnnotatedTypeTree) boundZero).getUnderlyingType();
         }
         paramClass = boundZero.toString();
@@ -357,7 +357,7 @@ public class IsSigMethodCriterion implements Criterion {
           List<? extends Tree> paramBounds = param.getBounds();
           if (paramBounds != null && paramBounds.size() >= 1) {
             Tree pb = paramBounds.get(0);
-            if (pb.getKind() == Tree.Kind.ANNOTATED_TYPE) {
+            if (pb instanceof AnnotatedTypeTree) {
               pb = ((AnnotatedTypeTree) pb).getUnderlyingType();
             }
             paramClass = pb.toString();

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/LambdaCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/LambdaCriterion.java
@@ -1,5 +1,6 @@
 package org.checkerframework.afu.annotator.find;
 
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.afu.annotator.scanner.LambdaScanner;
@@ -50,9 +51,8 @@ public class LambdaCriterion implements Criterion {
       return false;
     }
 
-    if (parent.getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
+    if (parent instanceof LambdaExpressionTree) {
       // LambdaExpressionTree lambdaTree = (LambdaExpressionTree) parent;
-
       int indexInSource = LambdaScanner.indexOfLambdaExpressionTree(path, parent);
       Criteria.dbug.debug("return source: %d%n", indexInSource);
       boolean b;

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/MemberReferenceCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/MemberReferenceCriterion.java
@@ -1,5 +1,6 @@
 package org.checkerframework.afu.annotator.find;
 
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.afu.annotator.scanner.MemberReferenceScanner;
@@ -31,7 +32,7 @@ public class MemberReferenceCriterion implements Criterion {
 
     Tree leaf = path.getLeaf();
 
-    if (leaf.getKind() == Tree.Kind.MEMBER_REFERENCE) {
+    if (leaf instanceof MemberReferenceTree) {
       int indexInSource = MemberReferenceScanner.indexOfMemberReferenceTree(path, leaf);
       boolean b;
       if (loc.isBytecodeOffset()) {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/NewCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/NewCriterion.java
@@ -1,5 +1,7 @@
 package org.checkerframework.afu.annotator.find;
 
+import com.sun.source.tree.NewArrayTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.afu.annotator.scanner.NewScanner;
@@ -51,7 +53,7 @@ public class NewCriterion implements Criterion {
       // anonymous inner class defined in another method.
       return this.isSatisfiedBy(path.getParentPath());
     }
-    if (leaf.getKind() == Tree.Kind.NEW_CLASS || leaf.getKind() == Tree.Kind.NEW_ARRAY) {
+    if (leaf instanceof NewClassTree || leaf instanceof NewArrayTree) {
       int indexInSource = NewScanner.indexOfNewTree(path, leaf);
       // System.out.printf("indexInSource=%d%n", indexInSource);
       boolean b;

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/PackageCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/PackageCriterion.java
@@ -1,6 +1,7 @@
 package org.checkerframework.afu.annotator.find;
 
 import com.sun.source.tree.*;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.afu.annotator.Main;
 
@@ -31,7 +32,7 @@ final class PackageCriterion implements Criterion {
         "PackageCriterion.isSatisfiedBy(%s, %s); this=%s%n",
         Main.leafString(path), tree, this.toString());
 
-    if (tree.getKind() == Tree.Kind.COMPILATION_UNIT) {
+    if (tree instanceof CompilationUnitTree) {
       CompilationUnitTree cu = (CompilationUnitTree) tree;
       if (cu.getSourceFile().getName().endsWith("package-info.java")) {
         ExpressionTree pn = cu.getPackageName();

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ReceiverCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ReceiverCriterion.java
@@ -2,6 +2,7 @@ package org.checkerframework.afu.annotator.find;
 
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 
 public class ReceiverCriterion implements Criterion {
@@ -30,7 +31,7 @@ public class ReceiverCriterion implements Criterion {
       return false;
     }
 
-    if (path.getLeaf().getKind() == Tree.Kind.METHOD) {
+    if (path.getLeaf() instanceof MethodTree) {
       if (isSigMethodCriterion.isSatisfiedBy(path)) {
         MethodTree leaf = (MethodTree) path.getLeaf();
         // If the method already has a receiver, then insert directly on the
@@ -47,8 +48,8 @@ public class ReceiverCriterion implements Criterion {
       // declaration.
       Tree param = null;
       TreePath parent = path;
-      while (parent != null && parent.getLeaf().getKind() != Tree.Kind.METHOD) {
-        if (parent.getLeaf().getKind() == Tree.Kind.VARIABLE) {
+      while (parent != null && !(parent.getLeaf() instanceof MethodTree)) {
+        if (parent.getLeaf() instanceof VariableTree) {
           if (param == null) {
             param = parent.getLeaf();
           } else {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ReturnTypeCriterion.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/ReturnTypeCriterion.java
@@ -1,5 +1,6 @@
 package org.checkerframework.afu.annotator.find;
 
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.afu.annotator.Main;
@@ -49,7 +50,7 @@ public class ReturnTypeCriterion implements Criterion {
         "ReturnTypeCriterion.isSatisfiedBy(%s); this=%s%n", Main.leafString(path), this.toString());
 
     do {
-      if (path.getLeaf().getKind() == Tree.Kind.METHOD) {
+      if (path.getLeaf() instanceof MethodTree) {
         if (sigMethodCriterion == null || sigMethodCriterion.isSatisfiedBy(path)) {
           // Method and return type verified; now check class.
           path = path.getParentPath();

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/TreeFinder.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/TreeFinder.java
@@ -154,10 +154,14 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
         + (c == '/' ? "" : nonDelimSlash);
   }
 
-  // If this code location is not an array type, return null.  Otherwise,
-  // starting at an array type, walk up the AST as long as still an array,
-  // and stop at the largest containing array (with nothing but arrays in
-  // between).
+  /**
+   * If this code location is not an array type, return null. Otherwise, starting at an array type,
+   * walk up the AST as long as still an array, and stop at the largest containing array (with
+   * nothing but arrays in between).
+   *
+   * @param p a tree path
+   * @return a path to the largest containing array, or null if none
+   */
   public static TreePath largestContainingArray(TreePath p) {
     if (!(p.getLeaf() instanceof ArrayTypeTree)) {
       return null;
@@ -476,6 +480,12 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
           0);
     }
 
+    /**
+     * Returns the number of array levels in the given tree, which may be 0.
+     *
+     * @param node a tree
+     * @return the number of array levels in the given tree
+     */
     private int arrayLevels(Tree node) {
       int result = 0;
       while (node instanceof ArrayTypeTree) {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/AnonymousClassScanner.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/AnonymousClassScanner.java
@@ -87,7 +87,7 @@ public class AnonymousClassScanner extends TreePathScanner<Void, Integer> {
   @Override
   public Void visitNewClass(NewClassTree node, Integer level) {
     // if (level < 2) {
-    if (!found && anonclass.getKind() == Tree.Kind.NEW_CLASS) {
+    if (!found && anonclass instanceof NewClassTree) {
       if (anonclass == node) {
         found = true;
       } else if (node.getClassBody() != null) {

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/TreePathUtil.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/TreePathUtil.java
@@ -47,6 +47,12 @@ public class TreePathUtil {
 
   // classes
 
+  /**
+   * Returns the enclosing class.
+   *
+   * @param path a tree path
+   * @return the enclosing class
+   */
   public static TreePath findEnclosingClass(TreePath path) {
     while (!hasClassKind(path.getLeaf())
         || path.getParentPath().getLeaf() instanceof NewClassTree) {
@@ -60,6 +66,12 @@ public class TreePathUtil {
 
   // methods
 
+  /**
+   * Returns the enclosing method.
+   *
+   * @param path a tree path
+   * @return the enclosing method
+   */
   public static TreePath findEnclosingMethod(TreePath path) {
     while (!(path.getLeaf() instanceof MethodTree)) {
       path = path.getParentPath();
@@ -72,6 +84,12 @@ public class TreePathUtil {
 
   // Field Initializers
 
+  /**
+   * Returns true if this is a field initialization.
+   *
+   * @param path a tree path
+   * @return true if this is a field initialization
+   */
   public static boolean isFieldInit(TreePath path) {
     return path.getLeaf() instanceof VariableTree
         && path.getParentPath() != null

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/TreePathUtil.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/TreePathUtil.java
@@ -6,7 +6,9 @@ import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.tree.JCTree;
 
@@ -35,7 +37,7 @@ public class TreePathUtil {
    */
   public static TreePath findCountingContext(TreePath path) {
     while (path != null) {
-      if (path.getLeaf().getKind() == Tree.Kind.METHOD || isFieldInit(path) || isInitBlock(path)) {
+      if (path.getLeaf() instanceof MethodTree || isFieldInit(path) || isInitBlock(path)) {
         return path;
       }
       path = path.getParentPath();
@@ -47,7 +49,7 @@ public class TreePathUtil {
 
   public static TreePath findEnclosingClass(TreePath path) {
     while (!hasClassKind(path.getLeaf())
-        || path.getParentPath().getLeaf().getKind() == Tree.Kind.NEW_CLASS) {
+        || path.getParentPath().getLeaf() instanceof NewClassTree) {
       path = path.getParentPath();
       if (path == null) {
         return null;
@@ -59,7 +61,7 @@ public class TreePathUtil {
   // methods
 
   public static TreePath findEnclosingMethod(TreePath path) {
-    while (path.getLeaf().getKind() != Tree.Kind.METHOD) {
+    while (!(path.getLeaf() instanceof MethodTree)) {
       path = path.getParentPath();
       if (path == null) {
         return null;
@@ -71,7 +73,7 @@ public class TreePathUtil {
   // Field Initializers
 
   public static boolean isFieldInit(TreePath path) {
-    return path.getLeaf().getKind() == Tree.Kind.VARIABLE
+    return path.getLeaf() instanceof VariableTree
         && path.getParentPath() != null
         && hasClassKind(path.getParentPath().getLeaf());
   }
@@ -95,7 +97,7 @@ public class TreePathUtil {
   public static boolean isInitBlock(TreePath path) {
     return path.getParentPath() != null
         && hasClassKind(path.getParentPath().getLeaf())
-        && path.getLeaf().getKind() == Tree.Kind.BLOCK;
+        && path.getLeaf() instanceof BlockTree;
   }
 
   public static TreePath findEnclosingInitBlock(TreePath path, boolean isStatic) {
@@ -147,7 +149,7 @@ public class TreePathUtil {
     int ctPos = -1;
 
     for (Tree member : ct.getMembers()) {
-      if (member.getKind() == Tree.Kind.METHOD) {
+      if (member instanceof MethodTree) {
         MethodTree method = (MethodTree) member;
         if (method.getName().contentEquals("<init>")) {
           // The tree contains the implicit default constructor if the user wrote no constructor,

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/ASTIndex.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/ASTIndex.java
@@ -258,7 +258,7 @@ public class ASTIndex extends WrapperMap<Tree, ASTRecord> {
             }
             saveAll(node.getTypeParameters(), rec, kind, ASTPath.TYPE_PARAMETER);
             for (Tree member : node.getMembers()) {
-              if (member.getKind() == Tree.Kind.BLOCK) {
+              if (member instanceof BlockTree) {
                 save(member, rec, kind, ASTPath.INITIALIZER, i++);
               } else if (ASTPath.isClassEquiv(member.getKind())) {
                 String className = ((JCTree.JCClassDecl) member).sym.flatname.toString();

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/ASTPath.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/io/ASTPath.java
@@ -1191,14 +1191,14 @@ public class ASTPath extends ImmutableStack<ASTPath.ASTEntry>
                 //   x instanceof Class<?>.
                 if (i > 0) { // TODO: refactor GenericArrayLoc to use same code?
                   Tree ancestor = actualPath.get(i - 1);
-                  if (ancestor.getKind() == Tree.Kind.INSTANCE_OF) {
+                  if (ancestor instanceof InstanceOfTree) {
                     System.err.println(
                         "WARNING: wildcard bounds not allowed"
                             + " in 'instanceof' expression; skipping insertion");
                     return false;
-                  } else if (i > 1 && ancestor.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+                  } else if (i > 1 && ancestor instanceof ParameterizedTypeTree) {
                     ancestor = actualPath.get(i - 2);
-                    if (ancestor.getKind() == Tree.Kind.ARRAY_TYPE) {
+                    if (ancestor instanceof ArrayTypeTree) {
                       System.err.println(
                           "WARNING: wildcard bounds not allowed"
                               + " in generic array type; skipping insertion");


### PR DESCRIPTION
Error Prone's suggestions violate the javac recommendations.  However, note that Error Prone does know that ` == Tree.Kind.SUPER_WILDCARD` and ` == Tree.Kind.EXTENDS_WILDCARD` cannot be replaced by `instanceof`, so it seems to have knowledge of this particular API, and the changes it made look OK to me.

Merge after #725.